### PR TITLE
Add shifts to poseset

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ pose_dataframe[PSDL.POSITION_X] = xyz[:, 0]
 Particle positions are coordinates in 2D or 3D images. The center of the first pixel is taken to be the origin `(0, 0)` or `(0, 0, 0)` and the units of particle positions are pixels.
 
 ### Shifts
-Particle shifts are in image pixels and are additive to positions, such that `POSITION + SHIFT` is the "real" position of the particle.
+Particle shifts are in image pixels and are additive to positions, such that `POSITION + SHIFT` is the position of the particle in the tomogram.
 
 ### Orientations
 Particle orientations are stored as

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ A `PoseSet` is a [pandas `DataFrame`](https://pandas.pydata.org/docs/) with spec
 | `x`             | POSITION_X    | particle position in x-dimension                     |
 | `y`             | POSITION_Y    | particle position in y-dimension                     |
 | `z`             | POSITION_Z    | particle position in z-dimension                     |
+| `dx`            | SHIFT_X       | particle shift in x-dimension                        |
+| `dy`            | SHIFT_Y       | particle shift in y-dimension                        |
+| `dz`            | SHIFT_Z       | particle shift in z-dimension                        |
 | `orientation`   | ORIENTATION   | particle orientation                                 |
 | `experiment_id` | EXPERIMENT_ID | experimental identifier for micrograph/tilt-series   |
 | `pixel_spacing` | PIXEL_SPACING | isotropic pixel/voxel spacing for particle positions |
@@ -37,6 +40,9 @@ pose_dataframe[PSDL.POSITION_X] = xyz[:, 0]
 
 ### Positions
 Particle positions are coordinates in 2D or 3D images. The center of the first pixel is taken to be the origin `(0, 0)` or `(0, 0, 0)` and the units of particle positions are pixels.
+
+### Shifts
+Particle shifts are in image pixels and are additive to positions, such that `POSITION + SHIFT` is the "real" position of the particle.
 
 ### Orientations
 Particle orientations are stored as

--- a/cryotypes/poseset/_constructor.py
+++ b/cryotypes/poseset/_constructor.py
@@ -22,6 +22,7 @@ def _construct_empty_poseset_df(ndim: Literal[2, 3] = 3) -> pd.DataFrame:
     return pd.DataFrame(
         columns=[
             *PSDL.POSITION[:ndim],
+            *PSDL.SHIFT[:ndim],
             PSDL.ORIENTATION,
             PSDL.PIXEL_SPACING,
             PSDL.EXPERIMENT_ID,
@@ -32,6 +33,7 @@ def _construct_empty_poseset_df(ndim: Literal[2, 3] = 3) -> pd.DataFrame:
 
 def construct_poseset_df(
     positions: np.ndarray,
+    shifts: np.ndarray | None = None,
     orientations: Rotation | None = None,
     experiment_ids: str | Sequence[str] | None = None,
     pixel_spacing_angstroms: float | Sequence[float] | None = None,
@@ -42,6 +44,10 @@ def construct_poseset_df(
     """Constructor for a valid poseset DataFrame."""
     df = _construct_empty_poseset_df(ndim)
     df[PSDL.POSITION[:ndim]] = validate_positions(positions, ndim)
+
+    if shifts is None:
+        shifts = np.zeros((len(positions), ndim))
+    df[PSDL.SHIFT[:ndim]] = validate_positions(shifts, ndim)
 
     if orientations is None:
         orientations = Rotation.identity(len(positions))

--- a/cryotypes/poseset/_data_labels.py
+++ b/cryotypes/poseset/_data_labels.py
@@ -4,6 +4,11 @@ class PoseSetDataLabels:
     POSITION_Z = "z"
     POSITION = [POSITION_X, POSITION_Y, POSITION_Z]
 
+    SHIFT_X = "dx"
+    SHIFT_Y = "dy"
+    SHIFT_Z = "dz"
+    SHIFT = [SHIFT_X, SHIFT_Y, SHIFT_Z]
+
     ORIENTATION = "orientation"
 
     EXPERIMENT_ID = "experiment_id"

--- a/cryotypes/poseset/_validators.py
+++ b/cryotypes/poseset/_validators.py
@@ -43,7 +43,7 @@ def validate_poseset_dataframe(
     if coerce:
         df = df.copy()
 
-    for col in PSDL.POSITION[:ndim]:
+    for col in PSDL.POSITION[:ndim] + PSDL.SHIFT[:ndim]:
         if col not in df:
             if not coerce:
                 raise KeyError(col)


### PR DESCRIPTION
It's important to track shifts due to their connection to refinement procedures; we shouldn't assume to always add them up with the positions.
